### PR TITLE
Add admin team stats

### DIFF
--- a/templates/adminteams.html
+++ b/templates/adminteams.html
@@ -18,6 +18,22 @@
       <a href="/admin/login">back to login</a>.
     </div>
   </div>
+
+  <div class="row">
+    <div class="col m-4">
+      {{ $advanced := 0 }}
+      {{ range $t := .Data.Teams }}
+        {{ if .Division .eq "Advanced" }}
+          {{ $advanced = $advanced + 1 }}
+        {{ end }}
+      {{ end }}
+
+      Registered Teams: {{ .Data.Teams }}
+      Advanced Competition: {{ $advanced }}
+      Beginner Competition: {{ .Data.Teams - $advanced }}
+    </div>
+  </div>
+
   {{ range $t := .Data.Teams }}
     <div class="row">
       <div class="col m-4">


### PR DESCRIPTION
@sumnerevans this is potentially awful code having not really used Go Templates before, but the idea is that we can display total registered teams + totals per each division rather than having to run DB queries. Maybe you could run a DB query and pass it through instead of me doing math? :) 