### PR TITLE
admin/volunteer login: redirect to existing page

### DIFF
--- a/internal/admin.go
+++ b/internal/admin.go
@@ -233,7 +233,7 @@ func (a *Application) HandleAdminLogin(w http.ResponseWriter, r *http.Request) {
 	} else {
 		log.Info().Msg("sent email")
 		http.SetCookie(w, &http.Cookie{Name: "admin_email", Value: emailAddress, Path: "/"})
-		w.Write([]byte("check your email for a login link"))
+		a.AdminConfirmEmailRenderer(w, r, map[string]any{"Email": emailAddress})
 	}
 }
 

--- a/internal/application.go
+++ b/internal/application.go
@@ -23,11 +23,13 @@ type Application struct {
 	EmailRegex *regexp.Regexp
 	Config     config.Configuration
 
-	ConfirmEmailRenderer       func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
-	TeacherLoginRenderer       func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
-	EmailLoginRenderer         func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
-	StudentConfirmInfoRenderer func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
-	TeamAddMemberRenderer      func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	ConfirmEmailRenderer          func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	VolunteerConfirmEmailRenderer func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	AdminConfirmEmailRenderer     func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	TeacherLoginRenderer          func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	EmailLoginRenderer            func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	StudentConfirmInfoRenderer    func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
+	TeamAddMemberRenderer         func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
 
 	TeacherCreateAccountRenderer func(w http.ResponseWriter, r *http.Request, extraData map[string]any)
 
@@ -139,6 +141,9 @@ func (a *Application) Start() {
 	a.TeacherLoginRenderer = a.ServeTemplateExtra(a.Log, "teacherlogin.html", a.GetEmailLoginTemplate)
 	a.TeacherCreateAccountRenderer = a.ServeTemplateExtra(a.Log, "teachercreateaccount.html", a.GetTeacherCreateAccountTemplate)
 	a.ConfirmEmailRenderer = a.ServeTemplateExtra(a.Log, "confirmemail.html", a.GetEmailLoginTemplate)
+	a.VolunteerConfirmEmailRenderer = a.ServeTemplateExtra(a.Log, "volunteerconfirmemail.html", a.GetEmailLoginTemplate)
+	a.AdminConfirmEmailRenderer = a.ServeTemplateExtra(a.Log, "adminconfirmemail.html", a.GetEmailLoginTemplate)
+
 	a.EmailLoginRenderer = a.ServeTemplateExtra(a.Log, "emaillogin.html", a.GetEmailLoginTemplate)
 	a.StudentConfirmInfoRenderer = a.ServeTemplateExtra(a.Log, "student.html", a.GetStudentConfirmInfoTemplate)
 	a.TeamAddMemberRenderer = a.ServeTemplateExtra(a.Log, "teamaddmember.html", a.GetTeacherAddMemberTemplate)
@@ -156,6 +161,10 @@ func (a *Application) Start() {
 
 		// Parent
 		"/register/parent/signforms": {a.ServeTemplateExtra(a.Log, "parent.html", a.GetParentSignFormsTemplate), false},
+
+		// Admin & Volunteer
+		"/register/volunteer/confirmemail": {a.VolunteerConfirmEmailRenderer, true},
+		"/register/admin/confirmemail":     {a.AdminConfirmEmailRenderer, true},
 	}
 	for path, rend := range registrationPages {
 		renderFn := func(path string, rend renderInfo) func(w http.ResponseWriter, r *http.Request) {

--- a/internal/volunteer.go
+++ b/internal/volunteer.go
@@ -115,7 +115,7 @@ func (a *Application) HandleVolunteerLogin(w http.ResponseWriter, r *http.Reques
 	} else {
 		log.Info().Msg("sent email")
 		http.SetCookie(w, &http.Cookie{Name: "volunteer_email", Value: emailAddress, Path: "/"})
-		w.Write([]byte("check your email for a login link"))
+		a.VolunteerConfirmEmailRenderer(w, r, map[string]any{"Email": emailAddress})
 	}
 }
 

--- a/website/templates/adminconfirmemail.html
+++ b/website/templates/adminconfirmemail.html
@@ -1,0 +1,37 @@
+{{ define "title" }}Confirm Email{{ end }}
+
+{{ define "content" }}
+<div class="container">
+  <div class="row page-header">
+    <div class="col">
+      <h1>Confirm Email</h1>
+    </div>
+  </div>
+</div>
+
+<div class="container page-content confirm-email">
+  {{ with .Data.Error }}
+    <div class="row">
+      <div class="alert alert-danger" role="alert">
+        <p>That login code was expired or invalid.</p>
+        <p>
+          Forgot to confirm your email?
+          <a href="mailto:support@mineshspc.com">Contact Support</a>.
+        </p>
+      </div>
+    </div>
+  {{ else }}
+    <div class="row">
+      <div class="col m-4 text-center">
+        <p>
+          We've sent an email to <b>{{ .Data.Email }}</b>.
+        </p>
+        <p style="font-size: 10em; line-height: 0;"><i class="fa fa-envelope-o"></i></p>
+        <p>
+          Please check your email and click the link to confirm your email address and log in.
+        </p>
+      </div>
+    </div>
+  {{ end }}
+</div>
+{{ end }}

--- a/website/templates/volunteerconfirmemail.html
+++ b/website/templates/volunteerconfirmemail.html
@@ -1,0 +1,37 @@
+{{ define "title" }}Confirm Email{{ end }}
+
+{{ define "content" }}
+<div class="container">
+  <div class="row page-header">
+    <div class="col">
+      <h1>Confirm Email</h1>
+    </div>
+  </div>
+</div>
+
+<div class="container page-content confirm-email">
+  {{ with .Data.Error }}
+    <div class="row">
+      <div class="alert alert-danger" role="alert">
+        <p>That login code was expired or invalid.</p>
+        <p>
+          Forgot to confirm your email?
+          <a href="mailto:support@mineshspc.com">Contact Support</a>.
+        </p>
+      </div>
+    </div>
+  {{ else }}
+    <div class="row">
+      <div class="col m-4 text-center">
+        <p>
+          Thanks for volunteering! We've sent an email to <b>{{ .Data.Email }}</b>.
+        </p>
+        <p style="font-size: 10em; line-height: 0;"><i class="fa fa-envelope-o"></i></p>
+        <p>
+          Please check your email and click the link to confirm your email address and log in.
+        </p>
+      </div>
+    </div>
+  {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
Okay, so the bytes of text (rather stupidly) bother me when logging in. I think we can just redirect to our pages for teachers which would be kind of nice. All of the text doesn't necessarily apply but it may not matter or we can add a boolean flag for this.