### PR TITLE
security: add HttpOnly, Secure, and SameSite flags to all cookies

### DIFF
--- a/internal/admin.go
+++ b/internal/admin.go
@@ -186,7 +186,7 @@ func (a *Application) HandleAdminEmailLogin(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	http.SetCookie(w, &http.Cookie{Name: "admin_token", Value: tok, Path: "/"})
+	http.SetCookie(w, &http.Cookie{Name: "admin_token", Value: tok, Path: "/", HttpOnly: true, Secure: !a.Config.DevMode, SameSite: http.SameSiteLaxMode})
 	http.Redirect(w, r, "/admin/teams", http.StatusSeeOther)
 }
 
@@ -239,7 +239,7 @@ func (a *Application) HandleAdminLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		log.Info().Msg("sent email")
-		http.SetCookie(w, &http.Cookie{Name: "admin_email", Value: emailAddress, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "admin_email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
 		a.AdminConfirmEmailRenderer(w, r, map[string]any{"Email": emailAddress})
 	}
 }

--- a/internal/logout.go
+++ b/internal/logout.go
@@ -6,6 +6,6 @@ import (
 )
 
 func (a *Application) HandleTeacherLogout(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{Name: "tok", Value: "", Path: "/", Expires: time.Unix(0, 0)})
+	http.SetCookie(w, &http.Cookie{Name: "tok", Value: "", Path: "/", Expires: time.Unix(0, 0), HttpOnly: true, Secure: !a.Config.DevMode, SameSite: http.SameSiteLaxMode})
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/internal/teachercreateaccount.go
+++ b/internal/teachercreateaccount.go
@@ -131,7 +131,7 @@ func (a *Application) HandleTeacherCreateAccount(w http.ResponseWriter, r *http.
 		return
 	} else {
 		log.Info().Msg("successfully sent email")
-		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
 		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
 	}
 }
@@ -200,7 +200,7 @@ func (a *Application) HandleTeacherEmailLogin(w http.ResponseWriter, r *http.Req
 		return
 	}
 	a.Log.Info().Any("jwt", jwt).Str("jwt_str", jwtStr).Msg("signed JWT")
-	http.SetCookie(w, &http.Cookie{Name: "tok", Value: jwtStr, Path: "/", Expires: expires})
+	http.SetCookie(w, &http.Cookie{Name: "tok", Value: jwtStr, Path: "/", Expires: expires, HttpOnly: true, Secure: !a.Config.DevMode, SameSite: http.SameSiteLaxMode})
 
 	if teacher.SchoolName == "" || teacher.SchoolCity == "" || teacher.SchoolState == "" {
 		http.Redirect(w, r, "/register/teacher/schoolinfo", http.StatusSeeOther)

--- a/internal/teacherlogin.go
+++ b/internal/teacherlogin.go
@@ -102,7 +102,7 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 		return
 	} else {
 		log.Info().Msg("sent email")
-		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
 		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 	}
 }

--- a/internal/volunteer.go
+++ b/internal/volunteer.go
@@ -61,7 +61,7 @@ func (a *Application) HandleVolunteerEmailLogin(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	http.SetCookie(w, &http.Cookie{Name: "volunteer_token", Value: tok, Path: "/"})
+	http.SetCookie(w, &http.Cookie{Name: "volunteer_token", Value: tok, Path: "/", HttpOnly: true, Secure: !a.Config.DevMode, SameSite: http.SameSiteLaxMode})
 	http.Redirect(w, r, "/volunteer/scan", http.StatusSeeOther)
 }
 
@@ -114,7 +114,7 @@ func (a *Application) HandleVolunteerLogin(w http.ResponseWriter, r *http.Reques
 		return
 	} else {
 		log.Info().Msg("sent email")
-		http.SetCookie(w, &http.Cookie{Name: "volunteer_email", Value: emailAddress, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "volunteer_email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
 		a.VolunteerConfirmEmailRenderer(w, r, map[string]any{"Email": emailAddress})
 	}
 }


### PR DESCRIPTION
## Summary

- Auth session cookies (`tok`, `admin_token`, `volunteer_token`) were missing `HttpOnly`, `Secure`, and `SameSite` flags
- Display-only email cookies also lacked `HttpOnly` and `SameSite`

**`HttpOnly`** — prevents XSS from stealing session tokens via `document.cookie`

**`Secure`** — ensures cookies are only sent over HTTPS (skipped when `DevMode: true` so local dev still works)

**`SameSite=Lax`** — blocks cross-site POST CSRF attacks while still allowing top-level navigation from email links

## Test plan

- [ ] Log in as teacher, confirm `tok` cookie has `HttpOnly; Secure; SameSite=Lax` in browser devtools
- [ ] Log in as admin, confirm `admin_token` has the same flags
- [ ] Log in as volunteer, confirm `volunteer_token` has the same flags
- [ ] Verify local dev (`dev_mode: true`) still works over HTTP (no `Secure` flag set)
- [ ] Verify logout clears `tok` cookie correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)