### PR TITLE
security: prevent email enumeration on teacher login

### DIFF
--- a/internal/teacherlogin.go
+++ b/internal/teacherlogin.go
@@ -63,12 +63,12 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to find teacher by email, redirecting without sending email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
 		return
 	} else if !teacher.EmailConfirmed {
 		log.Warn().Msg("teacher email not confirmed, redirecting without sending email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
 		return
 	}
 
@@ -99,6 +99,6 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 	} else {
 		log.Info().Msg("sent email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
 	}
 }

--- a/internal/teacherlogin.go
+++ b/internal/teacherlogin.go
@@ -61,18 +61,14 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 
 	teacher, err := a.DB.GetTeacherByEmail(r.Context(), emailAddress)
 	if err != nil {
-		log.Warn().Err(err).Msg("failed to find teacher by email")
-		a.TeacherLoginRenderer(w, r, map[string]any{
-			"Email":         emailAddress,
-			"EmailNotFound": true,
-		})
+		log.Warn().Err(err).Msg("failed to find teacher by email, redirecting without sending email")
+		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
+		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 		return
 	} else if !teacher.EmailConfirmed {
-		log.Warn().Err(err).Msg("teacher email not confirmed, not sending login code to avoid amplification attacks")
-		a.TeacherLoginRenderer(w, r, map[string]any{
-			"Email":             emailAddress,
-			"EmailNotConfirmed": true,
-		})
+		log.Warn().Msg("teacher email not confirmed, redirecting without sending email")
+		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
+		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 		return
 	}
 

--- a/internal/teacherlogin.go
+++ b/internal/teacherlogin.go
@@ -63,12 +63,12 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to find teacher by email, redirecting without sending email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 		return
 	} else if !teacher.EmailConfirmed {
 		log.Warn().Msg("teacher email not confirmed, redirecting without sending email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 		return
 	}
 
@@ -99,6 +99,6 @@ func (a *Application) HandleTeacherLogin(w http.ResponseWriter, r *http.Request)
 	} else {
 		log.Info().Msg("sent email")
 		http.SetCookie(w, &http.Cookie{Name: "email", Value: emailAddress, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode})
-		http.Redirect(w, r, "/register/teacher/confirmemail", http.StatusSeeOther)
+		http.Redirect(w, r, "/register/teacher/emaillogin", http.StatusSeeOther)
 	}
 }

--- a/website/templates/confirmemail.html
+++ b/website/templates/confirmemail.html
@@ -24,17 +24,15 @@
     <div class="row">
       <div class="col m-4 text-center">
         <p>
-          We've sent an email to <b>{{ .Data.Email }}</b>.
+          If <b>{{ .Data.Email }}</b> has a confirmed account, we've sent a login link to that address.
         </p>
         <p style="font-size: 10em; line-height: 0;"><i class="fa fa-envelope-o"></i></p>
         <p>
-          Please check your email and click the link to confirm your email address and log in.
+          Please check your email and click the link to log in.
         </p>
         <p>
-          <b>
-            You must confirm your email now, or you will have to contact the Mines HSPC team to get
-            your account activated.
-          </b>
+          If you haven't confirmed your email yet, check your inbox for the original confirmation email.
+          If you need help, <a href="mailto:support@mineshspc.com">contact support</a>.
         </p>
       </div>
     </div>

--- a/website/templates/confirmemail.html
+++ b/website/templates/confirmemail.html
@@ -24,15 +24,17 @@
     <div class="row">
       <div class="col m-4 text-center">
         <p>
-          If <b>{{ .Data.Email }}</b> has a confirmed account, we've sent a login link to that address.
+          We've sent an email to <b>{{ .Data.Email }}</b>.
         </p>
         <p style="font-size: 10em; line-height: 0;"><i class="fa fa-envelope-o"></i></p>
         <p>
-          Please check your email and click the link to log in.
+          Please check your email and click the link to confirm your email address and log in.
         </p>
         <p>
-          If you haven't confirmed your email yet, check your inbox for the original confirmation email.
-          If you need help, <a href="mailto:support@mineshspc.com">contact support</a>.
+          <b>
+            You must confirm your email now, or you will have to contact the Mines HSPC team to get
+            your account activated.
+          </b>
         </p>
       </div>
     </div>

--- a/website/templates/emaillogin.html
+++ b/website/templates/emaillogin.html
@@ -25,11 +25,13 @@
     <div class="row">
       <div class="col m-4 text-center">
         <p>
-          We've sent an email to <b>{{ .Data.Email }}</b>.
+          If <b>{{ .Data.Email }}</b> has a confirmed account, we've sent a login link to that address.
         </p>
         <p style="font-size: 10em; line-height: 0;"><i class="fa fa-envelope-o"></i></p>
         <p>
-          Please check your email and click the link to log in.
+          Please check your email and click the link to log in. If you haven't confirmed your email
+          yet, check your inbox for the original confirmation email. Need help?
+          <a href="mailto:support@mineshspc.com">Contact support</a>.
         </p>
       </div>
     </div>

--- a/website/templates/teacherlogin.html
+++ b/website/templates/teacherlogin.html
@@ -15,28 +15,9 @@
   <form method="post" action="/register/teacher/login" class="form-floating">
     <div class="row">
       <div class="col m-4 mb-0">
-        {{ with .Data.EmailNotFound }}
-          <div class="alert alert-danger" role="alert">
-            That email doesn't exist in our system. Did you want to
-            <a href="/register/teacher/createaccount">create an account</a> instead?
-          </div>
-        {{ else }}
-          {{ with .Data.EmailNotConfirmed }}
-            <div class="alert alert-danger" role="alert">
-              <p>
-                That email hasn't been confirmed yet. Please confirm your email before logging in.
-              </p>
-              <p>
-                Lost your confirmation email? Send an email to
-                <a href="mailto:support@mineshspc.com">support@mineshspc.com</a>.
-              </p>
-            </div>
-          {{ else }}
-            <div class="alert alert-secondary" role="alert">
-              Don't have an account? <a href="/register/teacher/createaccount">Create an account</a> instead.
-            </div>
-          {{ end }}
-        {{ end }}
+        <div class="alert alert-secondary" role="alert">
+          Don't have an account? <a href="/register/teacher/createaccount">Create an account</a> instead.
+        </div>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
## Summary

- Login form previously returned distinct errors for "email not found" vs "email not confirmed", letting an attacker enumerate which emails are registered
- Both failure cases now redirect to the same emaillogin page without sending an email, identical to the success response
- Removed the now-unreachable `EmailNotFound` and `EmailNotConfirmed` template blocks from `teacherlogin.html`
- Updated `emaillogin.html` text to reflect that a login link is only sent if the account exists and is confirmed, with guidance to check for the original confirmation email if not yet confirmed

## Test plan

- [ ] Submit login form with an unregistered email — should redirect to emaillogin page, no email sent
- [ ] Submit login form with a registered but unconfirmed email — same redirect, no email sent
- [ ] Submit login form with a valid confirmed email — redirects to emaillogin page and email is sent
- [ ] Confirm server logs still distinguish between the two failure cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)