### PR TITLE
ci: fix claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,4 +23,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review --comment'


### PR DESCRIPTION
## Summary

The prompt `/code-review:code-review <repo>/pull/<number>` is not valid syntax — the plugin registers the skill as `/code-review`, not `/code-review:code-review`. The `--comment` flag is also required to post inline PR comments instead of printing to stdout.

The marketplace URL (`https://github.com/anthropics/claude-code.git`) and plugin name (`code-review@claude-code-plugins`) were already correct — the marketplace manifest at `.claude-plugin/marketplace.json` in that repo declares `"name": "claude-code-plugins"`.

## Test plan

- [ ] Open a new PR → claude-code-review action runs and posts inline review comments

🤖 Generated with [Claude Code](https://claude.ai/claude-code)