### PR TITLE
admin: panel improvements (teachers page, pre-flight checklist, dietary CSV, etc.)

### DIFF
--- a/database/student.go
+++ b/database/student.go
@@ -104,3 +104,8 @@ func (d *Database) CheckInStudent(ctx context.Context, email string) error {
 	`, email)
 	return err
 }
+
+func (d *Database) UncheckInStudent(ctx context.Context, email string) error {
+	_, err := d.DB.Exec(ctx, `UPDATE students SET checkedin = false WHERE email = $1`, email)
+	return err
+}

--- a/database/teacher.go
+++ b/database/teacher.go
@@ -48,6 +48,37 @@ func (d *Database) scanTeacher(row dbutil.Scannable) (*Teacher, error) {
 	return &t, nil
 }
 
+func (d *Database) GetAllTeachers(ctx context.Context) ([]*Teacher, error) {
+	rows, err := d.DB.Query(ctx, `
+		SELECT t.name, t.email, t.emailconfirmed, t.emailallowance, t.schoolname, t.schoolcity, t.schoolstate
+		FROM teachers t
+		ORDER BY t.name
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var teachers []*Teacher
+	for rows.Next() {
+		teacher, err := d.scanTeacher(rows)
+		if err != nil {
+			return nil, err
+		}
+		teachers = append(teachers, teacher)
+	}
+	return teachers, rows.Err()
+}
+
+func (d *Database) SetEmailAllowance(ctx context.Context, email string, allowance int) error {
+	_, err := d.DB.Exec(ctx, `
+		UPDATE teachers
+		SET emailallowance = ?
+		WHERE email = ?
+	`, allowance, email)
+	return err
+}
+
 func (d *Database) GetTeacherByEmail(ctx context.Context, email string) (*Teacher, error) {
 	row := d.DB.QueryRow(ctx, `
 		SELECT t.name, t.email, t.emailconfirmed, t.emailallowance, t.schoolname, t.schoolcity, t.schoolstate

--- a/internal/admin.go
+++ b/internal/admin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -121,6 +122,40 @@ func (a *Application) GetAdminDietaryRestrictionsTemplate(r *http.Request) map[s
 	return map[string]any{
 		"DietaryRestrictions": dietaryRestrictions,
 	}
+}
+
+func (a *Application) GetAdminTeachersTemplate(r *http.Request) map[string]any {
+	teachers, err := a.DB.GetAllTeachers(r.Context())
+	if err != nil {
+		a.Log.Err(err).Msg("failed to get teachers")
+		return nil
+	}
+	return map[string]any{"Teachers": teachers}
+}
+
+func (a *Application) HandleAdminSetEmailAllowance(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		a.Log.Warn().Err(err).Msg("failed to parse form")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	email := r.FormValue("email")
+	allowanceStr := r.FormValue("allowance")
+	if email == "" || allowanceStr == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	allowance, err := strconv.Atoi(allowanceStr)
+	if err != nil || allowance < 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := a.DB.SetEmailAllowance(r.Context(), email, allowance); err != nil {
+		a.Log.Err(err).Msg("failed to set email allowance")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, "/admin/teachers", http.StatusSeeOther)
 }
 
 func (a *Application) HandleDietaryRestrictionsExport(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin.go
+++ b/internal/admin.go
@@ -661,6 +661,21 @@ func (a *Application) HandleManualCheckin(w http.ResponseWriter, r *http.Request
 	http.Redirect(w, r, "/admin/teams", http.StatusSeeOther)
 }
 
+func (a *Application) HandleManualUncheckin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	email := r.URL.Query().Get("email")
+	if email == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := a.DB.UncheckInStudent(ctx, email); err != nil {
+		a.Log.Err(err).Msg("failed to uncheck-in student")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, "/admin/teams", http.StatusSeeOther)
+}
+
 func (a *Application) HandleTeamList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	onlyFirstTime := r.URL.Query().Get("firsttime") == "true"

--- a/internal/admin.go
+++ b/internal/admin.go
@@ -123,6 +123,24 @@ func (a *Application) GetAdminDietaryRestrictionsTemplate(r *http.Request) map[s
 	}
 }
 
+func (a *Application) HandleDietaryRestrictionsExport(w http.ResponseWriter, r *http.Request) {
+	restrictions, err := a.DB.GetAllDietaryRestrictions(r.Context())
+	if err != nil {
+		a.Log.Err(err).Msg("failed to get dietary restrictions")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", `attachment; filename="dietary-restrictions.csv"`)
+	writer := csv.NewWriter(w)
+	writer.Write([]string{"Dietary Restriction"})
+	for _, r := range restrictions {
+		writer.Write([]string{r})
+	}
+	writer.Flush()
+}
+
 func (a *Application) HandleAdminEmailLogin(w http.ResponseWriter, r *http.Request) {
 	tok := r.URL.Query().Get("tok")
 	log := zerolog.Ctx(r.Context())

--- a/internal/admin.go
+++ b/internal/admin.go
@@ -124,6 +124,49 @@ func (a *Application) GetAdminDietaryRestrictionsTemplate(r *http.Request) map[s
 	}
 }
 
+type PreflightStudent struct {
+	Name     string
+	Email    string
+	TeamName string
+}
+
+func (a *Application) GetAdminPreflightTemplate(r *http.Request) map[string]any {
+	teams, err := a.DB.GetAdminTeamsWithTeacherName(r.Context())
+	if err != nil {
+		a.Log.Err(err).Msg("failed to get teams for preflight")
+		return nil
+	}
+
+	var unconfirmedEmail, unsignedForms, noQRCode, notCheckedIn []PreflightStudent
+	for _, team := range teams {
+		for _, student := range team.Members {
+			s := PreflightStudent{Name: student.Name, Email: student.Email, TeamName: team.Name}
+			if !student.EmailConfirmed {
+				unconfirmedEmail = append(unconfirmedEmail, s)
+				continue
+			}
+			if !student.LiabilitySigned || (team.InPerson && !student.ComputerUseWaiverSigned) {
+				unsignedForms = append(unsignedForms, s)
+				continue
+			}
+			if !student.QRCodeSent {
+				noQRCode = append(noQRCode, s)
+				continue
+			}
+			if team.InPerson && !student.CheckedIn {
+				notCheckedIn = append(notCheckedIn, s)
+			}
+		}
+	}
+
+	return map[string]any{
+		"UnconfirmedEmail": unconfirmedEmail,
+		"UnsignedForms":    unsignedForms,
+		"NoQRCode":         noQRCode,
+		"NotCheckedIn":     notCheckedIn,
+	}
+}
+
 func (a *Application) GetAdminTeachersTemplate(r *http.Request) map[string]any {
 	teachers, err := a.DB.GetAllTeachers(r.Context())
 	if err != nil {

--- a/internal/application.go
+++ b/internal/application.go
@@ -229,6 +229,8 @@ func (a *Application) BuildRouter() http.Handler {
 	adminRouter := http.NewServeMux()
 	adminRouter.HandleFunc("GET /{$}", a.ServeTemplate(a.Log, "adminhome.html", noArgs))
 	adminRouter.HandleFunc("GET /dietaryrestrictions", a.ServeTemplate(a.Log, "admindietaryrestrictions.html", a.GetAdminDietaryRestrictionsTemplate))
+	adminRouter.HandleFunc("GET /teachers", a.ServeTemplate(a.Log, "adminteachers.html", a.GetAdminTeachersTemplate))
+	adminRouter.HandleFunc("POST /teachers/allowance", a.HandleAdminSetEmailAllowance)
 	adminRouter.HandleFunc("GET /teams", a.ServeTemplate(a.Log, "adminteams.html", a.GetAdminTeamsTemplate))
 	adminRouter.HandleFunc("GET /volunteers", a.ServeTemplate(a.Log, "adminvolunteers.html", a.GetAdminVolunteersTemplate))
 	adminRouter.HandleFunc("POST /volunteers/add", a.HandleAdminAddVolunteer)

--- a/internal/application.go
+++ b/internal/application.go
@@ -248,6 +248,7 @@ func (a *Application) BuildRouter() http.Handler {
 	adminRouter.HandleFunc("GET /api/kattis/participants", a.HandleKattisParticipantsExport)
 	adminRouter.HandleFunc("GET /api/zoom/breakout", a.HandleZoomBreakoutExport)
 	adminRouter.HandleFunc("GET /api/manualcheckin", a.HandleManualCheckin)
+	adminRouter.HandleFunc("GET /api/manualuncheckin", a.HandleManualUncheckin)
 	adminRouter.HandleFunc("GET /api/team-list", a.HandleTeamList)
 	router.Handle("/admin/", http.StripPrefix("/admin", a.AdminAuthMiddleware(adminRouter)))
 	// Redirect /admin → /admin/ so the subrouter handles the home page in one place.

--- a/internal/application.go
+++ b/internal/application.go
@@ -233,6 +233,7 @@ func (a *Application) BuildRouter() http.Handler {
 	adminRouter.HandleFunc("GET /volunteers", a.ServeTemplate(a.Log, "adminvolunteers.html", a.GetAdminVolunteersTemplate))
 	adminRouter.HandleFunc("POST /volunteers/add", a.HandleAdminAddVolunteer)
 	adminRouter.HandleFunc("POST /volunteers/remove", a.HandleAdminRemoveVolunteer)
+	adminRouter.HandleFunc("GET /api/dietaryrestrictions", a.HandleDietaryRestrictionsExport)
 	adminRouter.HandleFunc("GET /api/resendstudentemail", a.HandleResendStudentEmail)
 	adminRouter.HandleFunc("GET /api/resendparentemail", a.HandleResendParentEmail)
 	adminRouter.HandleFunc("GET /api/confirmationlink/student", a.HandleGetStudentEmailConfirmationLink)

--- a/internal/application.go
+++ b/internal/application.go
@@ -229,6 +229,7 @@ func (a *Application) BuildRouter() http.Handler {
 	adminRouter := http.NewServeMux()
 	adminRouter.HandleFunc("GET /{$}", a.ServeTemplate(a.Log, "adminhome.html", noArgs))
 	adminRouter.HandleFunc("GET /dietaryrestrictions", a.ServeTemplate(a.Log, "admindietaryrestrictions.html", a.GetAdminDietaryRestrictionsTemplate))
+	adminRouter.HandleFunc("GET /preflight", a.ServeTemplate(a.Log, "adminpreflight.html", a.GetAdminPreflightTemplate))
 	adminRouter.HandleFunc("GET /teachers", a.ServeTemplate(a.Log, "adminteachers.html", a.GetAdminTeachersTemplate))
 	adminRouter.HandleFunc("POST /teachers/allowance", a.HandleAdminSetEmailAllowance)
 	adminRouter.HandleFunc("GET /teams", a.ServeTemplate(a.Log, "adminteams.html", a.GetAdminTeamsTemplate))

--- a/website/templates/admindietaryrestrictions.html
+++ b/website/templates/admindietaryrestrictions.html
@@ -14,8 +14,7 @@
 <div class="container page-content teacher">
   <div class="row">
     <div class="col m-4">
-      If you don't see anything, you might need to go
-      <a href="/admin/login">back to login</a>.
+      <a href="/admin/api/dietaryrestrictions" class="btn btn-primary">Download CSV</a>
     </div>
   </div>
   <table class="table">

--- a/website/templates/adminhome.html
+++ b/website/templates/adminhome.html
@@ -12,11 +12,6 @@
 <div class="container page-content rules">
   <div class="row">
     <div class="col m-4">
-      <p>
-        Note that all endpoints besides login require you to be logged in as an admin. I didn't
-        implement any redirects to the login page if you are not logged in (it just doesn't return
-        any data in those cases), so if no data shows up, re-authenticate using the login page.
-      </p>
       <ul>
         <li><a href="/admin/login">login</a></li>
         <li><a href="/admin/teams">teams</a></li>

--- a/website/templates/adminhome.html
+++ b/website/templates/adminhome.html
@@ -14,6 +14,7 @@
     <div class="col m-4">
       <ul>
         <li><a href="/admin/login">login</a></li>
+        <li><a href="/admin/preflight">pre-flight checklist</a></li>
         <li><a href="/admin/teachers">teachers</a></li>
         <li><a href="/admin/teams">teams</a></li>
         <li><a href="/admin/dietaryrestrictions">dietaryrestrictions</a></li>

--- a/website/templates/adminhome.html
+++ b/website/templates/adminhome.html
@@ -14,6 +14,7 @@
     <div class="col m-4">
       <ul>
         <li><a href="/admin/login">login</a></li>
+        <li><a href="/admin/teachers">teachers</a></li>
         <li><a href="/admin/teams">teams</a></li>
         <li><a href="/admin/dietaryrestrictions">dietaryrestrictions</a></li>
         <li><a href="/admin/volunteers">volunteers</a></li>

--- a/website/templates/adminpreflight.html
+++ b/website/templates/adminpreflight.html
@@ -1,0 +1,87 @@
+{{ define "title" }}Admin Pre-Flight Checklist{{ end }}
+
+{{ define "content" }}
+<div class="container page-header">
+  <div class="row">
+    <div class="col">
+      <h1>Pre-Flight Checklist</h1>
+      <p class="text-muted">Students still blocking themselves at each stage of the registration flow.</p>
+    </div>
+  </div>
+</div>
+
+<div class="container page-content">
+  <div class="row mb-4">
+    <div class="col">
+      <h2>Unconfirmed Email <span class="badge bg-secondary">{{ len .Data.UnconfirmedEmail }}</span></h2>
+      {{ if .Data.UnconfirmedEmail }}
+      <table class="table table-sm">
+        <thead><tr><th>Name</th><th>Email</th><th>Team</th></tr></thead>
+        <tbody>
+          {{ range .Data.UnconfirmedEmail }}
+          <tr><td>{{ .Name }}</td><td>{{ .Email }}</td><td>{{ .TeamName }}</td></tr>
+          {{ end }}
+        </tbody>
+      </table>
+      {{ else }}
+      <p class="text-muted">None.</p>
+      {{ end }}
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col">
+      <h2>Unsigned Forms <span class="badge bg-secondary">{{ len .Data.UnsignedForms }}</span></h2>
+      {{ if .Data.UnsignedForms }}
+      <table class="table table-sm">
+        <thead><tr><th>Name</th><th>Email</th><th>Team</th></tr></thead>
+        <tbody>
+          {{ range .Data.UnsignedForms }}
+          <tr><td>{{ .Name }}</td><td>{{ .Email }}</td><td>{{ .TeamName }}</td></tr>
+          {{ end }}
+        </tbody>
+      </table>
+      {{ else }}
+      <p class="text-muted">None.</p>
+      {{ end }}
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col">
+      <h2>QR Code Not Sent <span class="badge bg-secondary">{{ len .Data.NoQRCode }}</span></h2>
+      {{ if .Data.NoQRCode }}
+      <table class="table table-sm">
+        <thead><tr><th>Name</th><th>Email</th><th>Team</th></tr></thead>
+        <tbody>
+          {{ range .Data.NoQRCode }}
+          <tr><td>{{ .Name }}</td><td>{{ .Email }}</td><td>{{ .TeamName }}</td></tr>
+          {{ end }}
+        </tbody>
+      </table>
+      {{ else }}
+      <p class="text-muted">None.</p>
+      {{ end }}
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col">
+      <h2>Not Checked In <span class="badge bg-secondary">{{ len .Data.NotCheckedIn }}</span></h2>
+      <p class="text-muted small">In-person students who arrived at the previous stages but haven't scanned in.</p>
+      {{ if .Data.NotCheckedIn }}
+      <table class="table table-sm">
+        <thead><tr><th>Name</th><th>Email</th><th>Team</th></tr></thead>
+        <tbody>
+          {{ range .Data.NotCheckedIn }}
+          <tr><td>{{ .Name }}</td><td>{{ .Email }}</td><td>{{ .TeamName }}</td></tr>
+          {{ end }}
+        </tbody>
+      </table>
+      {{ else }}
+      <p class="text-muted">None.</p>
+      {{ end }}
+    </div>
+  </div>
+</div>
+{{ end }}

--- a/website/templates/adminteachers.html
+++ b/website/templates/adminteachers.html
@@ -1,0 +1,59 @@
+{{ define "title" }}Admin Teachers{{ end }}
+
+{{ define "content" }}
+<div class="container page-header">
+  <div class="row">
+    <div class="col">
+      <h1>Teachers</h1>
+    </div>
+  </div>
+</div>
+
+<div class="container page-content">
+  {{ if .Data.Teachers }}
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>School</th>
+        <th>Confirmed</th>
+        <th>Email Allowance</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range .Data.Teachers }}
+      <tr>
+        <td>{{ .Name }}</td>
+        <td>{{ .Email }}</td>
+        <td>
+          {{ if .SchoolName }}
+            {{ .SchoolName }}<br>
+            <small class="text-muted">{{ .SchoolCity }}, {{ .SchoolState }}</small>
+          {{ else }}
+            <span class="text-muted">—</span>
+          {{ end }}
+        </td>
+        <td>
+          {{ if .EmailConfirmed }}
+            <span class="badge bg-success">Yes</span>
+          {{ else }}
+            <span class="badge bg-warning text-dark">No</span>
+          {{ end }}
+        </td>
+        <td>
+          <form method="POST" action="/admin/teachers/allowance" class="d-flex gap-2 align-items-center">
+            <input type="hidden" name="email" value="{{ .Email }}">
+            <input type="number" name="allowance" value="{{ .EmailAllowance }}" min="0" class="form-control form-control-sm" style="width: 5rem;">
+            <button type="submit" class="btn btn-sm btn-primary">Update</button>
+          </form>
+        </td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ else }}
+  <p class="text-muted">No teachers registered.</p>
+  {{ end }}
+</div>
+{{ end }}

--- a/website/templates/adminteams.html
+++ b/website/templates/adminteams.html
@@ -264,6 +264,14 @@
                                 Checkin Manually
                               </a>
                             </small>
+                          {{ else }}
+                            <br>
+                            <small>
+                              <a href="/admin/api/manualuncheckin?email={{ .Email }}"
+                                 title="Reverse the check-in for this student.">
+                                Undo Check-in
+                              </a>
+                            </small>
                           {{ end }}
                         {{ end }}
                         {{ if not .EmailConfirmed }}


### PR DESCRIPTION
## Summary

Several admin panel improvements bundled together:

### Admin home
- Removed stale paragraph claiming auth doesn't redirect (the middleware now does)
- Added links to all pages (login, pre-flight, teachers, teams, dietary restrictions, volunteers)

### New: teachers page (`/admin/teachers`)
- Lists all teachers with name, email, school info, confirmation status
- Inline form to adjust each teacher's `emailallowance` (currently the only way to do this was to edit the SQLite DB by hand)
- New DB methods: `GetAllTeachers`, `SetEmailAllowance`

### New: pre-flight checklist (`/admin/preflight`)
- Buckets students by what's currently blocking them through the registration flow:
  - Unconfirmed email
  - Unsigned forms
  - QR code not sent
  - Not checked in (in-person only)
- Each student only appears in their earliest blocking bucket
- Quick way to answer "what still needs to happen before competition day" without scanning the full teams page

### New: dietary restrictions CSV export (`/admin/api/dietaryrestrictions`)
- Download button on the dietary restrictions page
- Single-column CSV, useful for handing off to caterers

### New: undo check-in (`/admin/api/manualuncheckin`)
- Reverses an accidental check-in
- Surfaced on the teams page as a link next to the QR code icon for checked-in students
- New DB method: `UncheckInStudent`

## Test plan

- [ ] `/admin/` shows all 6 page links, no stale text
- [ ] `/admin/teachers` lists all teachers, allowance form updates the DB
- [ ] `/admin/preflight` shows students bucketed correctly; empty buckets show "None"
- [ ] `/admin/dietaryrestrictions` has a Download CSV button that returns a single-column CSV
- [ ] On `/admin/teams`, checked-in students show "Undo Check-in" — clicking reverses it

🤖 Generated with [Claude Code](https://claude.ai/claude-code)